### PR TITLE
Add Scala quickstart example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+target

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ alt="VIMEO" width="240" border="10" /></a>
 ### Node.js
 
 1. Clone the repository
-2. Go to the _nodejs_ subdirectory
+2. Go to the _/nodejs_ subdirectory
 3. Update index.js to include your secret key and key ID from your [Smooch](https://app.smooch.io) settings
 ![Smooch App settings](http://i.imgur.com/oUlMAqz.png)
 ![Smooch Create new secret key](http://i.imgur.com/Yp7dlO3.png)
@@ -20,6 +20,31 @@ alt="VIMEO" width="240" border="10" /></a>
 7. Create a Facebook page and [connect it to Smooch](https://app.smooch.io/integrations/messenger)
 8. Create a Webhook from your [dashboard](https://app.smooch.io/integrations/webhook) and point it at the full url for the /messages endpoint (e.g. https://MY-NGROK-DOMAIN.ngrok.io/messages )
 9. Send messages to your Facebook page and watch the auto-replies roll in
+
+### Scala
+
+Go to _/scala_ subdirectory.
+
+Get a userId from your application and change
+
+```
+# Main.scala
+val userId = "aaaabbbb11112222ccccdddd"
+```
+
+Setup your app keyId and secret here
+```
+# application.conf
+smooch {
+  keyId = "app_aaaa1111bbbb3333cccc5555"
+  secret = "AAAA0000BBBB1111ccccDDDD"
+}
+```
+
+To run the webhook microservice, just do
+```
+$ sbt run
+```
 
 ### Python
 

--- a/scala/Main.scala
+++ b/scala/Main.scala
@@ -1,0 +1,87 @@
+import colossus.IOSystem
+import colossus.core.{ ServerContext, Initializer, WorkerRef, Server }
+import colossus.service.Callback
+import colossus.protocols.http.{ HttpMethod, HttpService }
+import colossus.protocols.http.UrlParsing._
+import akka.actor.ActorSystem
+
+class WebhookService(context: ServerContext, keyId: String, secret: String) extends HttpService(context) {
+  def handle = {
+    case request @ HttpMethod.Post on Root / "messages" => {
+      println(s"webhook PAYLOAD: \n $request")
+
+      val userId = "aaaabbbb11112222ccccdddd"
+      val text = "Live long and prosper"
+
+      (new SmoochClient(keyId, secret)).sendTextMessage(userId, text)
+      Callback.successful(request.ok(""))
+    }
+  }
+}
+
+class WebhookInitializer(worker: WorkerRef) extends Initializer(worker) {
+  def onConnect = context => {
+
+    import com.typesafe.config.ConfigFactory
+    val keyId = ConfigFactory.load.getString("smooch.keyId")
+    val secret = ConfigFactory.load.getString("smooch.secret")
+
+    new WebhookService(context, keyId, secret)
+  }
+}
+
+class JWTClient(keyId: String, secret: String) {
+  import io.jsonwebtoken.{ Jwts, SignatureAlgorithm }
+  import io.jsonwebtoken.JwsHeader.KEY_ID
+
+  def getJWT = {
+    val jwt = Jwts.builder()
+      .claim("scope", "app")
+      .setHeaderParam(KEY_ID, keyId)
+      .signWith(SignatureAlgorithm.HS256, secret.getBytes("UTF-8"))
+      .compact()
+
+    jwt
+  }
+}
+
+class SmoochClient(keyId: String, secret: String) {
+  import io.smooch.client.{ Configuration, ApiException }
+  import io.smooch.client.auth.ApiKeyAuth
+  import io.smooch.client.api._
+  import io.smooch.client.model._
+
+  val defaultClient = Configuration.getDefaultApiClient()
+  val jwToken: String = (new JWTClient(keyId, secret)).getJWT
+
+  private def initJWT = {
+    val jwt = defaultClient.getAuthentication("jwt").asInstanceOf[ApiKeyAuth]
+    jwt.setApiKey(jwToken)
+    jwt.setApiKeyPrefix("Bearer")
+  }
+
+  def sendTextMessage(userId: String, text: String) = {
+    initJWT
+
+    val apiInstance = new ConversationApi
+    val messagePostBody = new MessagePost
+    messagePostBody.setRole("appMaker")
+    messagePostBody.setType(MessagePost.TypeEnum.TEXT)
+    messagePostBody.setText(text)
+
+    try {
+      val result = apiInstance.postMessage(userId, messagePostBody)
+      println(s"API RESPONSE:\n $result")
+    } catch {
+      case e: ApiException =>
+        println(s"API ERROR:\n ${e.printStackTrace}");
+    }
+  }
+}
+
+object Main extends App {
+  implicit val actorSystem = ActorSystem()
+  implicit val iosys = IOSystem()
+
+  Server.start("smooch-quickstart", 9000) { new WebhookInitializer(_) }
+}

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,0 +1,11 @@
+name := "smooch-quickstart"
+version := "1.0"
+scalaVersion := "2.11.8"
+
+resolvers ++= Seq(
+  "Smooch Bintray Repo" at "http://dl.bintray.com/smoochorg/maven"
+)
+
+libraryDependencies += "com.tumblr" %% "colossus" % "0.8.4"
+libraryDependencies += "io.smooch" % "api" % "1.12.0"
+libraryDependencies += "io.jsonwebtoken" % "jjwt" % "0.7.0"

--- a/scala/src/main/resources/application.conf
+++ b/scala/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+smooch {
+  keyId = "app_aaaa1111bbbb3333cccc5555"
+  secret = "AAAA0000BBBB1111ccccDDDD"
+}


### PR DESCRIPTION
Hello, 

I did similar test code to the `/nodejs` folder example, writing a `POST /messages` route with a lightweight framework.

Java programmers will be able to use the code as well.